### PR TITLE
add return_result support

### DIFF
--- a/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/redact/RedactClient.java
+++ b/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/redact/RedactClient.java
@@ -4,59 +4,8 @@ import cloud.pangeacyber.pangea.Client;
 import cloud.pangeacyber.pangea.Config;
 import cloud.pangeacyber.pangea.exceptions.PangeaAPIException;
 import cloud.pangeacyber.pangea.exceptions.PangeaException;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-final class TextRequest {
-
-	@JsonProperty("text")
-	String text;
-
-	@JsonInclude(Include.NON_NULL)
-	@JsonProperty("debug")
-	Boolean debug = null;
-
-	@JsonInclude(Include.NON_NULL)
-	@JsonProperty("rules")
-	String[] rules = null;
-
-	public TextRequest(String text, Boolean debug, String[] rules) {
-		this.text = text;
-		this.debug = debug;
-		this.rules = rules;
-	}
-}
-
-final class StructuredRequest {
-
-	@JsonProperty("data")
-	Object data;
-
-	@JsonInclude(Include.NON_NULL)
-	@JsonProperty("jsonp")
-	String[] jsonp = null;
-
-	@JsonInclude(Include.NON_NULL)
-	@JsonProperty("format")
-	String format = null;
-
-	@JsonInclude(Include.NON_NULL)
-	@JsonProperty("debug")
-	Boolean debug = null;
-
-	@JsonInclude(Include.NON_NULL)
-	@JsonProperty("rules")
-	String[] rules = null;
-
-	StructuredRequest(Object data, String[] jsonp, String format, Boolean debug, String[] rules) {
-		this.data = data;
-		this.jsonp = jsonp;
-		this.format = format;
-		this.debug = debug;
-		this.rules = rules;
-	}
-}
+import cloud.pangeacyber.pangea.redact.requests.RedactStructuredRequest;
+import cloud.pangeacyber.pangea.redact.requests.RedactTextRequest;
 
 public class RedactClient extends Client {
 
@@ -66,21 +15,13 @@ public class RedactClient extends Client {
 		super(config, serviceName);
 	}
 
-	private RedactTextResponse redactPost(String text, Boolean debug, String[] rules)
-		throws PangeaException, PangeaAPIException {
-		TextRequest request = new TextRequest(text, debug, rules);
+	private RedactTextResponse redactPost(RedactTextRequest request) throws PangeaException, PangeaAPIException {
 		RedactTextResponse resp = doPost("/v1/redact", request, RedactTextResponse.class);
 		return resp;
 	}
 
-	private RedactStructuredResponse structuredPost(
-		Object data,
-		String format,
-		Boolean debug,
-		String[] jsonp,
-		String[] rules
-	) throws PangeaException, PangeaAPIException {
-		StructuredRequest request = new StructuredRequest(data, jsonp, null, debug, rules);
+	private RedactStructuredResponse structuredPost(RedactStructuredRequest request)
+		throws PangeaException, PangeaAPIException {
 		RedactStructuredResponse resp = doPost("/v1/redact_structured", request, RedactStructuredResponse.class);
 		return resp;
 	}
@@ -88,6 +29,7 @@ public class RedactClient extends Client {
 	/**
 	 * Redact
 	 * @pangea.description Redact sensitive information from provided text.
+	 * @deprecated use redactText(RedactTextRequest request) instead.
 	 * @param text The text data to redact.
 	 * @return RedactTextResponse
 	 * @throws PangeaException
@@ -98,12 +40,13 @@ public class RedactClient extends Client {
 	 * }
 	 */
 	public RedactTextResponse redactText(String text) throws PangeaException, PangeaAPIException {
-		return redactPost(text, null, null);
+		return redactPost(new RedactTextRequest.RedactTextRequestBuilder(text).build());
 	}
 
 	/**
 	 * Redact - text, debug
 	 * @pangea.description Redact sensitive information from provided text.
+	 * @deprecated use redactText(RedactTextRequest request) instead.
 	 * @param text The text data to redact.
 	 * @param debug Setting this value to true will provide a detailed analysis of the redacted data and the rules that caused redaction.
 	 * @return RedactTextResponse
@@ -115,12 +58,13 @@ public class RedactClient extends Client {
 	 * }
 	 */
 	public RedactTextResponse redactText(String text, boolean debug) throws PangeaException, PangeaAPIException {
-		return redactPost(text, debug, null);
+		return redactPost(new RedactTextRequest.RedactTextRequestBuilder(text).setDebug(debug).build());
 	}
 
 	/**
 	 * Redact - text, debug, rules
 	 * @pangea.description Redact sensitive information from provided text.
+	 * @deprecated use redactText(RedactTextRequest request) instead.
 	 * @param text The text data to redact.
 	 * @param debug Setting this value to true will provide a detailed analysis of the redacted data and the rules that caused redaction.
 	 * @param rules An array of redact rule short names.
@@ -134,12 +78,31 @@ public class RedactClient extends Client {
 	 */
 	public RedactTextResponse redactText(String text, Boolean debug, String[] rules)
 		throws PangeaException, PangeaAPIException {
-		return redactPost(text, debug, rules);
+		return redactPost(new RedactTextRequest.RedactTextRequestBuilder(text).setDebug(debug).setRules(rules).build());
+	}
+
+	/**
+	 * Redact
+	 * @pangea.description Redact sensitive information from provided text.
+	 * @param request redact request with text and optional parameters
+	 * @return RedactTextResponse
+	 * @throws PangeaException
+	 * @throws PangeaAPIException
+	 * @pangea.code
+	 * {@code
+	 * 		RedactTextResponse response = client.redactText(
+	 *			new RedactTextRequest.RedactTextRequestBuilder("Jenny Jenny... 415-867-5309").build()
+	 *		);
+	 * }
+	 */
+	public RedactTextResponse redactText(RedactTextRequest request) throws PangeaException, PangeaAPIException {
+		return redactPost(request);
 	}
 
 	/**
 	 * Redact structured
 	 * @pangea.description Redact sensitive information from structured data (e.g., JSON).
+	 * @deprecated use redactStructured(RedactStructuredRequest request) instead.
 	 * @param data Structured data to redact
 	 * @return RedactStructuredResponse
 	 * @throws PangeaException
@@ -155,12 +118,13 @@ public class RedactClient extends Client {
 	 * }
 	 */
 	public RedactStructuredResponse redactStructured(Object data) throws PangeaException, PangeaAPIException {
-		return structuredPost(data, null, null, null, null);
+		return structuredPost(new RedactStructuredRequest.RedactStructuredRequestBuilder(data).build());
 	}
 
 	/**
 	 * Redact structured - rules
 	 * @pangea.description Redact sensitive information from structured data (e.g., JSON).
+	 * @deprecated use redactStructured(RedactStructuredRequest request) instead.
 	 * @param data Structured data to redact
 	 * @param rules An array of redact rule short names
 	 * @return RedactStructuredResponse
@@ -178,12 +142,13 @@ public class RedactClient extends Client {
 	 */
 	public RedactStructuredResponse redactStructured(Object data, String[] rules)
 		throws PangeaException, PangeaAPIException {
-		return structuredPost(data, null, null, null, rules);
+		return structuredPost(new RedactStructuredRequest.RedactStructuredRequestBuilder(data).setRules(rules).build());
 	}
 
 	/**
 	 * Redact structured - data, format
 	 * @pangea.description Redact sensitive information from structured data (e.g., JSON).
+	 * @deprecated use redactStructured(RedactStructuredRequest request) instead.
 	 * @param data Structured data to redact
 	 * @param format format of data. Support "json"
 	 * @return RedactStructuredResponse
@@ -201,12 +166,15 @@ public class RedactClient extends Client {
 	 */
 	public RedactStructuredResponse redactStructured(Object data, String format)
 		throws PangeaException, PangeaAPIException {
-		return structuredPost(data, format, null, null, null);
+		return structuredPost(
+			new RedactStructuredRequest.RedactStructuredRequestBuilder(data).setFormat(format).build()
+		);
 	}
 
 	/**
 	 * Redact structured - data, debug
 	 * @pangea.description Redact sensitive information from structured data (e.g., JSON).
+	 * @deprecated use redactStructured(RedactStructuredRequest request) instead.
 	 * @param data Structured data to redact
 	 * @param debug Setting this value to true will provide a detailed analysis of the redacted data and the rules that caused redaction.
 	 * @return RedactStructuredResponse
@@ -224,12 +192,13 @@ public class RedactClient extends Client {
 	 */
 	public RedactStructuredResponse redactStructured(Object data, boolean debug)
 		throws PangeaException, PangeaAPIException {
-		return structuredPost(data, null, debug, null, null);
+		return structuredPost(new RedactStructuredRequest.RedactStructuredRequestBuilder(data).setDebug(debug).build());
 	}
 
 	/**
 	 * Redact structured - data, format, debug
 	 * @pangea.description Redact sensitive information from structured data (e.g., JSON).
+	 * @deprecated use redactStructured(RedactStructuredRequest request) instead.
 	 * @param data Structured data to redact
 	 * @param format format of data. Support "json"
 	 * @param debug Setting this value to true will provide a detailed analysis of the redacted data and the rules that caused redaction.
@@ -248,12 +217,15 @@ public class RedactClient extends Client {
 	 */
 	public RedactStructuredResponse redactStructured(Object data, String format, boolean debug)
 		throws PangeaException, PangeaAPIException {
-		return structuredPost(data, format, debug, null, null);
+		return structuredPost(
+			new RedactStructuredRequest.RedactStructuredRequestBuilder(data).setFormat(format).setDebug(debug).build()
+		);
 	}
 
 	/**
 	 * Redact structured - data, debug, jsonp
 	 * @pangea.description Redact sensitive information from structured data (e.g., JSON).
+	 * @deprecated use redactStructured(RedactStructuredRequest request) instead.
 	 * @param data Structured data to redact
 	 * @param debug Setting this value to true will provide a detailed analysis of the redacted data and the rules that caused redaction.
 	 * @param jsonp JSON path(s) used to identify the specific JSON fields to redact in the structured data. Note: data parameter must be in JSON format.
@@ -272,12 +244,15 @@ public class RedactClient extends Client {
 	 */
 	public RedactStructuredResponse redactStructured(Object data, boolean debug, String[] jsonp)
 		throws PangeaException, PangeaAPIException {
-		return structuredPost(data, null, debug, jsonp, null);
+		return structuredPost(
+			new RedactStructuredRequest.RedactStructuredRequestBuilder(data).setDebug(debug).setJsonp(jsonp).build()
+		);
 	}
 
 	/**
 	 * Redact structured - data, debug, jsonp, rules
 	 * @pangea.description Redact sensitive information from structured data (e.g., JSON).
+	 * @deprecated use redactStructured(RedactStructuredRequest request) instead.
 	 * @param data Structured data to redact
 	 * @param debug Setting this value to true will provide a detailed analysis of the redacted data and the rules that caused redaction.
 	 * @param jsonp JSON path(s) used to identify the specific JSON fields to redact in the structured data. Note: data parameter must be in JSON format.
@@ -297,6 +272,39 @@ public class RedactClient extends Client {
 	 */
 	public RedactStructuredResponse redactStructured(Object data, boolean debug, String[] jsonp, String[] rules)
 		throws PangeaException, PangeaAPIException {
-		return structuredPost(data, null, debug, jsonp, rules);
+		return structuredPost(
+			new RedactStructuredRequest.RedactStructuredRequestBuilder(data)
+				.setDebug(debug)
+				.setJsonp(jsonp)
+				.setRules(rules)
+				.build()
+		);
+	}
+
+	/**
+	 * Redact structured
+	 * @pangea.description Redact sensitive information from structured data (e.g., JSON).
+	 * @param request redact structured request with object data and optional parameters
+	 * @return RedactStructuredResponse
+	 * @throws PangeaException
+	 * @throws PangeaAPIException
+	 * @pangea.code
+	 * {@code
+	 * Map<String, Object> data = new LinkedHashMap<String, Object>();
+	 *
+	 * data.put("Name", "Jenny Jenny");
+	 * data.put("Phone", "This is its number: 415-867-5309");
+	 *
+	 *	RedactStructuredResponse response = client.redactStructured(
+	 *		new RedactStructuredRequest.RedactStructuredRequestBuilder(data)
+	 *			.setDebug(true)
+	 *			.setJsonp(new String[] { "Phone", "Name" })
+	 *			.setRules(new String[] { "PHONE_NUMBER" })
+	 *			.build()
+	 *	);
+	 */
+	public RedactStructuredResponse redactStructured(RedactStructuredRequest request)
+		throws PangeaException, PangeaAPIException {
+		return structuredPost(request);
 	}
 }

--- a/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/redact/requests/RedactStructuredRequest.java
+++ b/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/redact/requests/RedactStructuredRequest.java
@@ -1,0 +1,107 @@
+package cloud.pangeacyber.pangea.redact.requests;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RedactStructuredRequest {
+
+	@JsonProperty("data")
+	Object data;
+
+	@JsonInclude(Include.NON_NULL)
+	@JsonProperty("jsonp")
+	String[] jsonp = null;
+
+	@JsonInclude(Include.NON_NULL)
+	@JsonProperty("format")
+	String format = null;
+
+	@JsonInclude(Include.NON_NULL)
+	@JsonProperty("debug")
+	Boolean debug = null;
+
+	@JsonInclude(Include.NON_NULL)
+	@JsonProperty("rules")
+	String[] rules = null;
+
+	@JsonInclude(Include.NON_NULL)
+	@JsonProperty("return_result")
+	Boolean returnResult = null;
+
+	protected RedactStructuredRequest(RedactStructuredRequestBuilder builder) {
+		this.data = builder.data;
+		this.jsonp = builder.jsonp;
+		this.format = builder.format;
+		this.debug = builder.debug;
+		this.rules = builder.rules;
+		this.returnResult = builder.returnResult;
+	}
+
+	public Object getData() {
+		return data;
+	}
+
+	public String[] getJsonp() {
+		return jsonp;
+	}
+
+	public String getFormat() {
+		return format;
+	}
+
+	public Boolean getDebug() {
+		return debug;
+	}
+
+	public String[] getRules() {
+		return rules;
+	}
+
+	public Boolean getReturnResult() {
+		return returnResult;
+	}
+
+	public static class RedactStructuredRequestBuilder {
+
+		Object data;
+		String[] jsonp = null;
+		String format = null;
+		Boolean debug = null;
+		String[] rules = null;
+		Boolean returnResult = null;
+
+		public RedactStructuredRequestBuilder(Object data) {
+			this.data = data;
+		}
+
+		public RedactStructuredRequest build() {
+			return new RedactStructuredRequest(this);
+		}
+
+		public RedactStructuredRequestBuilder setJsonp(String[] jsonp) {
+			this.jsonp = jsonp;
+			return this;
+		}
+
+		public RedactStructuredRequestBuilder setFormat(String format) {
+			this.format = format;
+			return this;
+		}
+
+		public RedactStructuredRequestBuilder setDebug(Boolean debug) {
+			this.debug = debug;
+			return this;
+		}
+
+		public RedactStructuredRequestBuilder setRules(String[] rules) {
+			this.rules = rules;
+			return this;
+		}
+
+		public RedactStructuredRequestBuilder setReturnResult(Boolean returnResult) {
+			this.returnResult = returnResult;
+			return this;
+		}
+	}
+}

--- a/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/redact/requests/RedactTextRequest.java
+++ b/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/redact/requests/RedactTextRequest.java
@@ -1,0 +1,77 @@
+package cloud.pangeacyber.pangea.redact.requests;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RedactTextRequest {
+
+	@JsonProperty("text")
+	String text;
+
+	@JsonInclude(Include.NON_NULL)
+	@JsonProperty("debug")
+	Boolean debug = null;
+
+	@JsonInclude(Include.NON_NULL)
+	@JsonProperty("rules")
+	String[] rules = null;
+
+	@JsonInclude(Include.NON_NULL)
+	@JsonProperty("return_result")
+	Boolean returnResult = null;
+
+	protected RedactTextRequest(RedactTextRequestBuilder builder) {
+		this.text = builder.text;
+		this.debug = builder.debug;
+		this.rules = builder.rules;
+		this.returnResult = builder.returnResult;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public Boolean getDebug() {
+		return debug;
+	}
+
+	public String[] getRules() {
+		return rules;
+	}
+
+	public Boolean getReturnResult() {
+		return returnResult;
+	}
+
+	public static class RedactTextRequestBuilder {
+
+		String text;
+		Boolean debug = null;
+		String[] rules = null;
+		Boolean returnResult = null;
+
+		public RedactTextRequestBuilder(String text) {
+			this.text = text;
+		}
+
+		public RedactTextRequest build() {
+			return new RedactTextRequest(this);
+		}
+
+		public RedactTextRequestBuilder setDebug(Boolean debug) {
+			this.debug = debug;
+			return this;
+		}
+
+		public RedactTextRequestBuilder setRules(String[] rules) {
+			this.rules = rules;
+			return this;
+		}
+
+		public RedactTextRequestBuilder setReturnResult(Boolean returnResult) {
+			this.returnResult = returnResult;
+			return this;
+		}
+	}
+}

--- a/packages/pangea-sdk/src/test/java/cloud/pangeacyber/pangea/redact/ITRedactTest.java
+++ b/packages/pangea-sdk/src/test/java/cloud/pangeacyber/pangea/redact/ITRedactTest.java
@@ -11,6 +11,8 @@ import cloud.pangeacyber.pangea.exceptions.ConfigException;
 import cloud.pangeacyber.pangea.exceptions.PangeaAPIException;
 import cloud.pangeacyber.pangea.exceptions.PangeaException;
 import cloud.pangeacyber.pangea.exceptions.UnauthorizedException;
+import cloud.pangeacyber.pangea.redact.requests.RedactStructuredRequest;
+import cloud.pangeacyber.pangea.redact.requests.RedactTextRequest;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.Before;
@@ -50,6 +52,43 @@ public class ITRedactTest {
 	@Test
 	public void testRedact_3() throws PangeaException, PangeaAPIException {
 		RedactTextResponse response = client.redactText("Jenny Jenny... 415-867-5309", false);
+		assertTrue(response.isOk());
+
+		RedactTextResult result = response.getResult();
+		assertEquals("<PERSON>... <PHONE_NUMBER>", result.getRedactedText());
+		assertNull(result.getReport());
+	}
+
+	@Test
+	public void testRedactRequest_1() throws PangeaException, PangeaAPIException {
+		RedactTextResponse response = client.redactText(
+			new RedactTextRequest.RedactTextRequestBuilder("Jenny Jenny... 415-867-5309").build()
+		);
+		assertTrue(response.isOk());
+
+		RedactTextResult result = response.getResult();
+		assertEquals("<PERSON>... <PHONE_NUMBER>", result.getRedactedText());
+		assertEquals(2, result.getCount());
+		assertNull(result.getReport());
+	}
+
+	@Test
+	public void testRedactRequest_2() throws PangeaException, PangeaAPIException {
+		RedactTextResponse response = client.redactText(
+			new RedactTextRequest.RedactTextRequestBuilder("Jenny Jenny... 415-867-5309").setDebug(true).build()
+		);
+		assertTrue(response.isOk());
+
+		RedactTextResult result = response.getResult();
+		assertEquals("<PERSON>... <PHONE_NUMBER>", result.getRedactedText());
+		assertNotNull(result.getReport());
+	}
+
+	@Test
+	public void testRedactRequest_3() throws PangeaException, PangeaAPIException {
+		RedactTextResponse response = client.redactText(
+			new RedactTextRequest.RedactTextRequestBuilder("Jenny Jenny... 415-867-5309").setDebug(false).build()
+		);
 		assertTrue(response.isOk());
 
 		RedactTextResult result = response.getResult();
@@ -215,12 +254,192 @@ public class ITRedactTest {
 		assertNotNull(result.getReport());
 	}
 
+	@Test
+	public void testStructuredRequest_1() throws PangeaException, PangeaAPIException {
+		Map<String, Object> data = new LinkedHashMap<String, Object>();
+		data.put("Name", "Jenny Jenny");
+		data.put("Phone", "This is its number: 415-867-5309");
+
+		RedactStructuredResponse response = client.redactStructured(
+			new RedactStructuredRequest.RedactStructuredRequestBuilder(data).build()
+		);
+		assertTrue(response.isOk());
+
+		RedactStructuredResult result = response.getResult();
+
+		Map<String, Object> expected = new LinkedHashMap<String, Object>();
+		expected.put("Name", "<PERSON>");
+		expected.put("Phone", "This is its number: <PHONE_NUMBER>");
+		assertEquals(2, result.getCount());
+
+		assertEquals(expected, result.getRedactedData());
+		assertNull(result.getReport());
+	}
+
+	@Test
+	public void testStructuredRequest_2() throws PangeaException, PangeaAPIException {
+		Map<String, Object> data = new LinkedHashMap<String, Object>();
+		data.put("Name", "Jenny Jenny");
+		data.put("Phone", "This is its number: 415-867-5309");
+
+		RedactStructuredResponse response = client.redactStructured(
+			new RedactStructuredRequest.RedactStructuredRequestBuilder(data).setFormat("json").build()
+		);
+		assertTrue(response.isOk());
+
+		RedactStructuredResult result = response.getResult();
+
+		Map<String, Object> expected = new LinkedHashMap<String, Object>();
+		expected.put("Name", "<PERSON>");
+		expected.put("Phone", "This is its number: <PHONE_NUMBER>");
+
+		assertEquals(expected, result.getRedactedData());
+		assertNull(result.getReport());
+	}
+
+	@Test
+	public void testStructuredRequest_3() throws PangeaException, PangeaAPIException {
+		Map<String, Object> data = new LinkedHashMap<String, Object>();
+		data.put("Name", "Jenny Jenny");
+		data.put("Phone", "This is its number: 415-867-5309");
+
+		RedactStructuredResponse response = client.redactStructured(
+			new RedactStructuredRequest.RedactStructuredRequestBuilder(data).setDebug(true).build()
+		);
+		assertTrue(response.isOk());
+
+		RedactStructuredResult result = response.getResult();
+
+		Map<String, Object> expected = new LinkedHashMap<String, Object>();
+		expected.put("Name", "<PERSON>");
+		expected.put("Phone", "This is its number: <PHONE_NUMBER>");
+
+		assertEquals(expected, result.getRedactedData());
+		assertNotNull(result.getReport());
+	}
+
+	@Test
+	public void testStructuredRequest_4() throws PangeaException, PangeaAPIException {
+		Map<String, Object> data = new LinkedHashMap<String, Object>();
+		data.put("Name", "Jenny Jenny");
+		data.put("Phone", "This is its number: 415-867-5309");
+
+		RedactStructuredResponse response = client.redactStructured(
+			new RedactStructuredRequest.RedactStructuredRequestBuilder(data).setDebug(false).build()
+		);
+		assertTrue(response.isOk());
+
+		RedactStructuredResult result = response.getResult();
+
+		Map<String, Object> expected = new LinkedHashMap<String, Object>();
+		expected.put("Name", "<PERSON>");
+		expected.put("Phone", "This is its number: <PHONE_NUMBER>");
+
+		assertEquals(expected, result.getRedactedData());
+		assertNull(result.getReport());
+	}
+
+	@Test
+	public void testStructuredRequest_5() throws PangeaException, PangeaAPIException {
+		Map<String, Object> data = new LinkedHashMap<String, Object>();
+		data.put("Name", "Jenny Jenny");
+		data.put("Phone", "This is its number: 415-867-5309");
+
+		RedactStructuredResponse response = client.redactStructured(
+			new RedactStructuredRequest.RedactStructuredRequestBuilder(data).setFormat("json").setDebug(true).build()
+		);
+		assertTrue(response.isOk());
+
+		RedactStructuredResult result = response.getResult();
+
+		Map<String, Object> expected = new LinkedHashMap<String, Object>();
+		expected.put("Name", "<PERSON>");
+		expected.put("Phone", "This is its number: <PHONE_NUMBER>");
+
+		assertEquals(expected, result.getRedactedData());
+		assertNotNull(result.getReport());
+	}
+
+	@Test
+	public void testStructuredRequest_6() throws PangeaException, PangeaAPIException {
+		Map<String, Object> data = new LinkedHashMap<String, Object>();
+		data.put("Name", "Jenny Jenny");
+		data.put("Phone", "This is its number: 415-867-5309");
+
+		RedactStructuredResponse response = client.redactStructured(
+			new RedactStructuredRequest.RedactStructuredRequestBuilder(data)
+				.setDebug(true)
+				.setJsonp(new String[] { "Phone" })
+				.build()
+		);
+		assertTrue(response.isOk());
+
+		RedactStructuredResult result = response.getResult();
+
+		Map<String, Object> expected = new LinkedHashMap<String, Object>();
+		expected.put("Name", "Jenny Jenny");
+		expected.put("Phone", "This is its number: <PHONE_NUMBER>");
+
+		assertEquals(expected, result.getRedactedData());
+		assertNotNull(result.getReport());
+	}
+
+	@Test
+	public void testStructuredRequest_7() throws PangeaException, PangeaAPIException {
+		Map<String, Object> data = new LinkedHashMap<String, Object>();
+		data.put("Name", "Jenny Jenny");
+		data.put("Phone", "This is its number: 415-867-5309");
+
+		RedactStructuredResponse response = client.redactStructured(
+			new RedactStructuredRequest.RedactStructuredRequestBuilder(data)
+				.setRules(new String[] { "PHONE_NUMBER" })
+				.build()
+		);
+		assertTrue(response.isOk());
+
+		RedactStructuredResult result = response.getResult();
+
+		Map<String, Object> expected = new LinkedHashMap<String, Object>();
+		expected.put("Name", "Jenny Jenny");
+		expected.put("Phone", "This is its number: <PHONE_NUMBER>");
+
+		assertEquals(expected, result.getRedactedData());
+		assertNull(result.getReport());
+	}
+
+	@Test
+	public void testStructuredRequest_8() throws PangeaException, PangeaAPIException {
+		Map<String, Object> data = new LinkedHashMap<String, Object>();
+		data.put("Name", "Jenny Jenny");
+		data.put("Phone", "This is its number: 415-867-5309");
+
+		RedactStructuredResponse response = client.redactStructured(
+			new RedactStructuredRequest.RedactStructuredRequestBuilder(data)
+				.setDebug(true)
+				.setJsonp(new String[] { "Phone", "Name" })
+				.setRules(new String[] { "PHONE_NUMBER" })
+				.build()
+		);
+		assertTrue(response.isOk());
+
+		RedactStructuredResult result = response.getResult();
+
+		Map<String, Object> expected = new LinkedHashMap<String, Object>();
+		expected.put("Name", "Jenny Jenny");
+		expected.put("Phone", "This is its number: <PHONE_NUMBER>");
+
+		assertEquals(expected, result.getRedactedData());
+		assertNotNull(result.getReport());
+	}
+
 	@Test(expected = UnauthorizedException.class)
 	public void testRedactTextUnauthorized() throws PangeaException, PangeaAPIException, ConfigException {
 		Config cfg = Config.fromIntegrationEnvironment(environment);
 		cfg.setToken("notarealtoken");
 		RedactClient fakeClient = new RedactClient(cfg);
-		RedactTextResponse response = fakeClient.redactText("Jenny Jenny... 415-867-5309", false);
+		RedactTextResponse response = fakeClient.redactText(
+			new RedactTextRequest.RedactTextRequestBuilder("My name is Jenny Jenny").build()
+		);
 	}
 
 	@Test(expected = UnauthorizedException.class)
@@ -231,6 +450,8 @@ public class ITRedactTest {
 		Map<String, Object> data = new LinkedHashMap<String, Object>();
 		data.put("Name", "Jenny Jenny");
 		data.put("Phone", "This is its number: 415-867-5309");
-		RedactStructuredResponse response = fakeClient.redactStructured(data, true, new String[] { "Phone" });
+		RedactStructuredResponse response = fakeClient.redactStructured(
+			new RedactStructuredRequest.RedactStructuredRequestBuilder(data).build()
+		);
 	}
 }


### PR DESCRIPTION
- Create new TextRequest and StructuredRequest classes and builders due to we have many optional parameters
- Mark old methods as deprecated to incentive users to use new request/builders methods