### PR TITLE
Add operation ID tag to mvn javadoc config

### DIFF
--- a/packages/pangea-sdk/pom.xml
+++ b/packages/pangea-sdk/pom.xml
@@ -345,6 +345,11 @@
               <placement>a</placement>
               <head>Example:</head>
             </tag>
+            <tag>
+              <name>pangea.operationId</name>
+              <placement>a</placement>
+              <head>Operation ID:</head>
+            </tag>
           </tags>
         </configuration>
       </plugin>


### PR DESCRIPTION
This fixes the error from `mvn javadoc:javadoc` that complains about our custom javadoc tag: `@pangea.operationId`