### PR TITLE
Add CI for examples (GEA-11806)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,10 @@ jobs:
       - name: Calculate `examples-matrix` output
         id: examples-matrix
         working-directory: ./examples
-        run: find . -type f -name 'pom.xml' -printf '%h\n' | cut -c 3- | sort -u | jq -cRs '"examples-matrix=" + (split("\n") | tostring)' >> "$GITHUB_OUTPUT"
+        run: |
+          find . -type f -name 'pom.xml' -printf '%h\n'
+          find . -type f -name 'pom.xml' -printf '%h\n' | cut -c 3- | sort -u | jq -cRs '"examples-matrix=" + (split("\n") | tostring)'
+          find . -type f -name 'pom.xml' -printf '%h\n' | cut -c 3- | sort -u | jq -cRs '"examples-matrix=" + (split("\n") | tostring)' >> "$GITHUB_OUTPUT"
 
   prefetch:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,10 @@ jobs:
       - name: Calculate `examples-matrix` output
         id: examples-matrix
         working-directory: ./examples
-        run: find . -type f -name 'pom.xml' -printf '%h\n' | cut -c 3- | sort -u | jq -cRrs '"examples-matrix=" + (split("\n") | tostring)' >> "$GITHUB_OUTPUT"
+        env:
+          JQ_FILTER: >-
+            "examples-matrix=" + (split("\n") | map(select(length > 0)) | tostring)
+        run: find . -type f -name 'pom.xml' -printf '%h\n' | cut -c 3- | sort -u | jq -cRrs '${{ env.JQ_FILTER }}' >> "$GITHUB_OUTPUT"
 
   prefetch:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       examples-matrix: ${{ steps.examples-matrix.outputs.examples-matrix }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.1
+
       - name: Calculate `examples-matrix` output
         id: examples-matrix
         working-directory: ./examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,7 @@ jobs:
       - name: Calculate `examples-matrix` output
         id: examples-matrix
         working-directory: ./examples
-        run: |
-          find . -type f -name 'pom.xml' -printf '%h\n'
-          find . -type f -name 'pom.xml' -printf '%h\n' | cut -c 3- | sort -u | jq -cRs '"examples-matrix=" + (split("\n") | tostring)'
-          find . -type f -name 'pom.xml' -printf '%h\n' | cut -c 3- | sort -u | jq -cRs '"examples-matrix=" + (split("\n") | tostring)' >> "$GITHUB_OUTPUT"
+        run: find . -type f -name 'pom.xml' -printf '%h\n' | cut -c 3- | sort -u | jq -cRrs '"examples-matrix=" + (split("\n") | tostring)' >> "$GITHUB_OUTPUT"
 
   prefetch:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,113 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+  merge_group:
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prefetch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Java
+        uses: actions/setup-java@v4.0.0
+        with:
+          distribution: microsoft
+          java-version: 21
+
+  examples:
+    needs: [prefetch]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        example:
+          - audit/audit_multiconfig
+          - audit/log
+          - audit/log_bulk
+          - audit/log_bulk_async
+          - audit/log_bulk_async_with_vault
+          - audit/log_n_sign
+          - audit/log_verbose
+          - audit/root
+          - audit/search
+          - authn/invite_actions
+          - authn/user_actions
+          - embargo/ip_check
+          - embargo/iso_check
+          - file_scan/file_scan_async_crowdstrike
+          - file_scan/file_scan_async_reversinglabs
+          - file_scan/file_scan_request_upload_url_post
+          - file_scan/file_scan_request_upload_url_put
+          - file_scan/file_scan_sync_crowdstrike
+          - file_scan/file_scan_sync_reversinglabs
+          - intel/defang/defang
+          - intel/domain/reputation
+          - intel/domain/reputation_bulk
+          - intel/domain/whois
+          - intel/file/reputation
+          - intel/file/reputation_bulk
+          - intel/file/reputation_filepath
+          - intel/ip/geolocate
+          - intel/ip/geolocate_bulk
+          - intel/ip/get_domain
+          - intel/ip/get_domain_bulk
+          - intel/ip/is_proxy
+          - intel/ip/is_proxy_bulk
+          - intel/ip/is_vpn
+          - intel/ip/is_vpn_bulk
+          - intel/ip/reputation_bulk
+          - intel/ip/reputation_crowdstrike
+          - intel/ip/reputation_cymru
+          - intel/url/reputation
+          - intel/user/password_breached
+          - intel/user/user_breached_by_email
+          - intel/user/user_breached_by_ip
+          - intel/user/user_breached_by_phone
+          - intel/user/user_breached_by_username
+          - redact/redact_multiconfig
+          - redact/structured
+          - redact/text
+          - vault/encrypt
+          - vault/encrypt_structured
+          - vault/get
+          - vault/rotate
+          - vault/sign
+        java-version: [17, 21]
+    defaults:
+      run:
+        working-directory: ./examples/${{ matrix.example }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Java
+        uses: actions/setup-java@v4.0.0
+        with:
+          distribution: microsoft
+          java-version: ${{ matrix.java-version }}
+          cache: maven
+          cache-dependency-path: ./examples/${{ matrix.example }}/pom.xml
+
+      - name: Build
+        run: mvn -B package --file pom.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+
+    outputs:
+      examples-matrix: ${{ steps.examples-matrix.outputs.examples-matrix }}
+
+    steps:
+      - name: Calculate `examples-matrix` output
+        id: examples-matrix
+        working-directory: ./examples
+        run: find . -type f -name 'pom.xml' -printf '%h\n' | cut -c 3- | sort -u | jq -cRs '"examples-matrix=" + (split("\n") | tostring)' >> "$GITHUB_OUTPUT"
+
   prefetch:
     runs-on: ubuntu-latest
     steps:
@@ -37,62 +49,11 @@ jobs:
           java-version: 21
 
   examples:
-    needs: [prefetch]
+    needs: [setup, prefetch]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        example:
-          - audit/audit_multiconfig
-          - audit/log
-          - audit/log_bulk
-          - audit/log_bulk_async
-          - audit/log_bulk_async_with_vault
-          - audit/log_n_sign
-          - audit/log_verbose
-          - audit/root
-          - audit/search
-          - authn/invite_actions
-          - authn/user_actions
-          - embargo/ip_check
-          - embargo/iso_check
-          - file_scan/file_scan_async_crowdstrike
-          - file_scan/file_scan_async_reversinglabs
-          - file_scan/file_scan_request_upload_url_post
-          - file_scan/file_scan_request_upload_url_put
-          - file_scan/file_scan_sync_crowdstrike
-          - file_scan/file_scan_sync_reversinglabs
-          - intel/defang/defang
-          - intel/domain/reputation
-          - intel/domain/reputation_bulk
-          - intel/domain/whois
-          - intel/file/reputation
-          - intel/file/reputation_bulk
-          - intel/file/reputation_filepath
-          - intel/ip/geolocate
-          - intel/ip/geolocate_bulk
-          - intel/ip/get_domain
-          - intel/ip/get_domain_bulk
-          - intel/ip/is_proxy
-          - intel/ip/is_proxy_bulk
-          - intel/ip/is_vpn
-          - intel/ip/is_vpn_bulk
-          - intel/ip/reputation_bulk
-          - intel/ip/reputation_crowdstrike
-          - intel/ip/reputation_cymru
-          - intel/url/reputation
-          - intel/user/password_breached
-          - intel/user/user_breached_by_email
-          - intel/user/user_breached_by_ip
-          - intel/user/user_breached_by_phone
-          - intel/user/user_breached_by_username
-          - redact/redact_multiconfig
-          - redact/structured
-          - redact/text
-          - vault/encrypt
-          - vault/encrypt_structured
-          - vault/get
-          - vault/rotate
-          - vault/sign
+        example: ${{ fromJSON(needs.setup.outputs.examples-matrix) }}
         java-version: [17, 21]
     defaults:
       run:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,8 @@ stages:
   - build
   - test
   - publish
+  - examples
 
 include:
   - /packages/pangea-sdk/.sdk-ci.yml
+  - /examples/.examples-ci.yml

--- a/dev/run_all_examples.sh
+++ b/dev/run_all_examples.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 # Root directory
 root_directory=$(pwd)
 

--- a/dev/run_all_examples.sh
+++ b/dev/run_all_examples.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Root directory
 root_directory=$(pwd)

--- a/examples/.examples-ci.yml
+++ b/examples/.examples-ci.yml
@@ -1,0 +1,86 @@
+examples:
+  stage: examples
+  needs: []
+  parallel:
+    matrix:
+      - JAVA_VERSION: [21]
+        EXAMPLE:
+          - audit/audit_multiconfig
+          - audit/log
+          - audit/log_bulk
+          - audit/log_bulk_async
+          - audit/log_n_sign
+          - audit/log_verbose
+          - audit/root
+          - audit/search
+          - authn/invite_actions
+          - authn/user_actions
+          - embargo/ip_check
+          - embargo/iso_check
+          - file_scan/file_scan_async_crowdstrike
+          - file_scan/file_scan_async_reversinglabs
+          - file_scan/file_scan_request_upload_url_post
+          - file_scan/file_scan_request_upload_url_put
+          - file_scan/file_scan_sync_crowdstrike
+          - file_scan/file_scan_sync_reversinglabs
+          - intel/defang/defang
+          - intel/domain/reputation
+          - intel/domain/reputation_bulk
+          - intel/domain/whois
+          - intel/file/reputation
+          - intel/file/reputation_bulk
+          - intel/file/reputation_filepath
+          - intel/ip/geolocate
+          - intel/ip/geolocate_bulk
+          - intel/ip/get_domain
+          - intel/ip/get_domain_bulk
+          - intel/ip/is_proxy
+          - intel/ip/is_proxy_bulk
+          - intel/ip/is_vpn
+          - intel/ip/is_vpn_bulk
+          - intel/ip/reputation_bulk
+          - intel/ip/reputation_crowdstrike
+          - intel/ip/reputation_cymru
+          - intel/url/reputation
+          - intel/user/password_breached
+          - intel/user/user_breached_by_email
+          - intel/user/user_breached_by_ip
+          - intel/user/user_breached_by_phone
+          - intel/user/user_breached_by_username
+          - redact/redact_multiconfig
+          - redact/structured
+          - redact/text
+          - vault/encrypt
+          - vault/encrypt_structured
+          - vault/rotate
+          - vault/sign
+
+          # Depends on a `PANGEA_AUDIT_TOKEN_VAULT_ID` which isn't in CI.
+          # - audit/log_bulk_async_with_vault
+
+          # Depends on a `PANGEA_AUDIT_TOKEN_ID` which isn't in CI.
+          # - vault/get
+  image: maven:3.9.6-eclipse-temurin-${JAVA_VERSION}
+  before_script:
+    - export PANGEA_AUDIT_CONFIG_ID="$(eval echo \$PANGEA_AUDIT_CONFIG_ID_1_LVE)"
+    - export PANGEA_AUDIT_CUSTOM_SCHEMA_TOKEN="$(eval echo \$PANGEA_INTEGRATION_CUSTOM_SCHEMA_TOKEN_LVE)"
+    - export PANGEA_AUDIT_MULTICONFIG_TOKEN="$(eval echo \$PANGEA_INTEGRATION_MULTI_CONFIG_TOKEN_LVE)"
+    - export PANGEA_AUDIT_TOKEN="$(eval echo \$PANGEA_INTEGRATION_TOKEN_LVE)"
+    - export PANGEA_AUTHN_TOKEN="$(eval echo \$PANGEA_INTEGRATION_TOKEN_LVE)"
+    - export PANGEA_DOMAIN_INTEL_TOKEN="$(eval echo \$PANGEA_INTEGRATION_TOKEN_LVE)"
+    - export PANGEA_DOMAIN="$(eval echo \$PANGEA_INTEGRATION_DOMAIN_LVE)"
+    - export PANGEA_EMBARGO_TOKEN="$(eval echo \$PANGEA_INTEGRATION_TOKEN_LVE)"
+    - export PANGEA_FILE_INTEL_TOKEN="$(eval echo \$PANGEA_INTEGRATION_TOKEN_LVE)"
+    - export PANGEA_FILE_SCAN_TOKEN="$(eval echo \$PANGEA_INTEGRATION_TOKEN_LVE)"
+    - export PANGEA_INTEL_TOKEN="$(eval echo \$PANGEA_INTEGRATION_TOKEN_LVE)"
+    - export PANGEA_IP_INTEL_TOKEN="$(eval echo \$PANGEA_INTEGRATION_TOKEN_LVE)"
+    - export PANGEA_REDACT_CONFIG_ID="$(eval echo \$PANGEA_REDACT_CONFIG_ID_1_LVE)"
+    - export PANGEA_REDACT_MULTICONFIG_TOKEN="$(eval echo \$PANGEA_INTEGRATION_MULTI_CONFIG_TOKEN_LVE)"
+    - export PANGEA_REDACT_TOKEN="$(eval echo \$PANGEA_INTEGRATION_TOKEN_LVE)"
+    - export PANGEA_URL_INTEL_TOKEN="$(eval echo \$PANGEA_INTEGRATION_TOKEN_LVE)"
+    - export PANGEA_USER_INTEL_TOKEN="$(eval echo \$PANGEA_INTEGRATION_TOKEN_LVE)"
+    - export PANGEA_VAULT_TOKEN="$(eval echo \$PANGEA_INTEGRATION_TOKEN_LVE)"
+  script:
+    - cd examples/${EXAMPLE}
+    - mvn -B compile
+    - mvn -B exec:java -Dexec.mainClass=cloud.pangeacyber.examples.App

--- a/examples/audit/audit_multiconfig/pom.xml
+++ b/examples/audit/audit_multiconfig/pom.xml
@@ -5,10 +5,10 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>cloud.pangeacyber.examples</groupId>
-  <artifactId>log</artifactId>
+  <artifactId>audit_multiconfig</artifactId>
   <version>2.0.0</version>
 
-  <name>log</name>
+  <name>audit_multiconfig</name>
   <url>http://pangea.cloud</url>
 
   <properties>

--- a/examples/audit/log_bulk/pom.xml
+++ b/examples/audit/log_bulk/pom.xml
@@ -5,10 +5,10 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>cloud.pangeacyber.examples</groupId>
-  <artifactId>log</artifactId>
+  <artifactId>log_bulk</artifactId>
   <version>2.0.0</version>
 
-  <name>log</name>
+  <name>log_bulk</name>
   <url>http://pangea.cloud</url>
 
   <properties>

--- a/examples/audit/log_bulk_async/pom.xml
+++ b/examples/audit/log_bulk_async/pom.xml
@@ -5,10 +5,10 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>cloud.pangeacyber.examples</groupId>
-  <artifactId>log</artifactId>
+  <artifactId>log_bulk_async</artifactId>
   <version>2.0.0</version>
 
-  <name>log</name>
+  <name>log_bulk_async</name>
   <url>http://pangea.cloud</url>
 
   <properties>

--- a/examples/audit/log_bulk_async_with_vault/pom.xml
+++ b/examples/audit/log_bulk_async_with_vault/pom.xml
@@ -5,10 +5,10 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>cloud.pangeacyber.examples</groupId>
-  <artifactId>log</artifactId>
+  <artifactId>log_bulk_async_with_vault</artifactId>
   <version>2.0.0</version>
 
-  <name>log</name>
+  <name>log_bulk_async_with_vault</name>
   <url>http://pangea.cloud</url>
 
   <properties>

--- a/examples/authn/invite_actions/pom.xml
+++ b/examples/authn/invite_actions/pom.xml
@@ -21,4 +21,15 @@
       <version>3.6.0</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.12.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/examples/authn/invite_actions/pom.xml
+++ b/examples/authn/invite_actions/pom.xml
@@ -8,97 +8,17 @@
   <artifactId>invite_actions</artifactId>
   <version>1.0.0</version>
 
-  <name>vault_encrypt</name>
-  <url>http://pangea.cloud</url>
-
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
-  <repositories>
-      <repository>
-        <id>ossrh</id>
-        <name>ossrh-snapshot</name>
-        <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        <snapshots>
-            <enabled>true</enabled>
-          <updatePolicy>always</updatePolicy>
-        </snapshots>
-        <releases>
-            <enabled>false</enabled>
-        </releases>
-      </repository>
-  </repositories>
-
   <dependencies>
     <dependency>
       <groupId>cloud.pangea</groupId>
       <artifactId>pangea-sdk</artifactId>
-      <version>3.5.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
-      <scope>test</scope>
+      <version>3.6.0</version>
     </dependency>
   </dependencies>
-
-  <build>
-    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
-      <plugins>
-        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
-        <plugin>
-          <artifactId>maven-clean-plugin</artifactId>
-          <version>3.1.0</version>
-        </plugin>
-        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
-        <plugin>
-          <artifactId>maven-resources-plugin</artifactId>
-          <version>3.0.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>3.1.0</version>
-          <configuration>
-            <archive>
-              <manifest>
-                <addClasspath>true</addClasspath>
-                <mainClass>cloud.pangeacyber.examples.App</mainClass>
-              </manifest>
-            </archive>
-          </configuration>
-        </plugin>
-        <plugin>
-          <artifactId>maven-install-plugin</artifactId>
-          <version>2.5.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.8.2</version>
-        </plugin>
-        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
-        <plugin>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>3.7.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.0.0</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 </project>

--- a/examples/authn/invite_actions/src/main/java/cloud/pangeacyber/examples/App.java
+++ b/examples/authn/invite_actions/src/main/java/cloud/pangeacyber/examples/App.java
@@ -26,7 +26,6 @@ public class App
 	);
 	private static final Profile profileInitial = new Profile();
 	private static final Profile profileUpdate = new Profile();
-	private static String userID = ""; // Will be set once user is created
 
     public static void main( String[] args )
     {
@@ -52,7 +51,7 @@ public class App
                 new UserInviteRequest.Builder(
                     userEmail,
                     emailInviteKeep,
-                    "https://www.usgs.gov/faqs/what-was-pangea",
+                    "https://someurl.com/callbacklink",
                     "somestate")
                     .build()
             );
@@ -65,7 +64,7 @@ public class App
                 new UserInviteRequest.Builder(
                     userEmail,
                     emailInviteDelete,
-                    "https://www.usgs.gov/faqs/what-was-pangea",
+                    "https://someurl.com/callbacklink",
                     "somestate"
                     ).build()
                     );
@@ -89,12 +88,10 @@ public class App
                 new UserInviteListRequest.Builder().build()
             );
             System.out.println(String.format("There is %d invites.", inviteListResp1.getResult().getCount()));
-
 		} catch (PangeaAPIException | PangeaException e) {
             System.out.println("Something went wrong.");
 			System.out.println(e.toString());
 			System.exit(1);
 		}
-
     }
 }

--- a/examples/vault/encrypt_structured/pom.xml
+++ b/examples/vault/encrypt_structured/pom.xml
@@ -8,28 +8,10 @@
   <artifactId>encrypt_structured</artifactId>
   <version>1.0.0</version>
 
-  <name>vault_encrypt_structured</name>
-  <url>https://pangea.cloud</url>
-
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.release>21</maven.compiler.release>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
-
-  <repositories>
-    <repository>
-      <id>ossrh</id>
-      <name>ossrh-snapshot</name>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>always</updatePolicy>
-      </snapshots>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </repository>
-  </repositories>
 
   <dependencies>
     <dependency>
@@ -37,67 +19,5 @@
       <artifactId>pangea-sdk</artifactId>
       <version>3.6.0</version>
     </dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
-
-  <build>
-    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
-      <plugins>
-        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
-        <plugin>
-          <artifactId>maven-clean-plugin</artifactId>
-          <version>3.1.0</version>
-        </plugin>
-        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
-        <plugin>
-          <artifactId>maven-resources-plugin</artifactId>
-          <version>3.0.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.12.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>3.1.0</version>
-          <configuration>
-            <archive>
-              <manifest>
-                <addClasspath>true</addClasspath>
-                <mainClass>cloud.pangeacyber.examples.App</mainClass>
-              </manifest>
-            </archive>
-          </configuration>
-        </plugin>
-        <plugin>
-          <artifactId>maven-install-plugin</artifactId>
-          <version>2.5.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.8.2</version>
-        </plugin>
-        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
-        <plugin>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>3.7.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.0.0</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 </project>

--- a/examples/vault/encrypt_structured/pom.xml
+++ b/examples/vault/encrypt_structured/pom.xml
@@ -20,4 +20,15 @@
       <version>3.6.0</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.12.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>


### PR DESCRIPTION
## Included

- Dependabot config for keeping GitHub Actions updated.
- Examples are built on GitHub Actions.
- Examples run on GitLab and use the existing secrets we have there.

## Not included

- Dependabot config for anything else. This would be super easy to add but I'll be doing this in future work.
- Running the examples on GitHub Actions. This would be a nice-to-have but would require mirroring the secrets from GitLab.
- A few new examples require environment variables that don't exist in our GitLab CI; I excluded these examples from the pipeline.
- Multi-cloud execution. Would be easy enough to add but in my opinion the point of this pipeline is to test that the examples work, not that AWS/GCP work. If some example happens to not work in GCP that's a GCP issue and should be caught by an integration test somewhere else, not by this examples pipeline.