### PR TITLE
Remove duplicate dependencies (GEA-12269)

### DIFF
--- a/packages/pangea-sdk/pom.xml
+++ b/packages/pangea-sdk/pom.xml
@@ -107,16 +107,6 @@
       <version>4.5.13</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>2.20.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpmime</artifactId>
-      <version>4.5.14</version>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>2.14.1</version>


### PR DESCRIPTION
log4j-core and httpmime are already specified earlier in the dependencies list