### PR TITLE
Fix docs gen on constructors and type params (GEA-12432)

### DIFF
--- a/packages/jsondoclet/src/main/java/cloud/pangea/JsonDoclet.java
+++ b/packages/jsondoclet/src/main/java/cloud/pangea/JsonDoclet.java
@@ -43,7 +43,7 @@ public class JsonDoclet implements Doclet {
             props.put(e.getKind().toString(), e.toString());
             props.put("fullBody", docCommentTree.getFullBody().toString());
 
-            if (e.getKind() == ElementKind.METHOD) {
+            if (e.getKind() == ElementKind.CONSTRUCTOR || e.getKind() == ElementKind.METHOD) {
                 types = getTypesFromMethod(e.toString());
             }
 
@@ -53,7 +53,10 @@ public class JsonDoclet implements Doclet {
 
                 switch (t.getKind()) {
                     case PARAM:
-                        paramTags.add(processParamDocComment(t.toString()));
+                        var paramTag = processParamDocComment(t.toString());
+						if (paramTag != null) {
+							paramTags.add(paramTag);
+						}
                         break;
                     case RETURN:
                       HashMap<String, Object> returnComment = processDocComment(t.toString());
@@ -191,6 +194,11 @@ public class JsonDoclet implements Doclet {
 
         String[] splitComment = comment.split(" ");
         String[] textArr = Arrays.copyOfRange(splitComment, 2, splitComment.length);
+
+		// HACK: do nothing with type params.
+		if (splitComment[1].startsWith("<") && splitComment[1].endsWith(">")) {
+			return null;
+		}
 
         param.put("name", splitComment[1]);
         param.put("text", String.join(" ", textArr));


### PR DESCRIPTION
Type params were not being handled properly, plus the docs site cannot display them anyways. Additionally, the types for constructor params were not being parsed either.

Fixes:

    [ERROR] error: fatal error encountered: java.lang.ArrayIndexOutOfBoundsException: Index 3 out of bounds for length 3
    [ERROR] error: Please file a bug against the javadoc tool via the Java bug reporting page
    [ERROR]   (https://bugreport.java.com) after checking the Bug Database (https://bugs.java.com)
    [ERROR]   for duplicates. Include error messages and the following diagnostic in your report. Thank you.
    [ERROR] java.lang.ArrayIndexOutOfBoundsException: Index 3 out of bounds for length 3
    [ERROR]         at cloud.pangea.JsonDoclet.printElement(JsonDoclet.java:93)
    [ERROR]         at cloud.pangea.JsonDoclet.run(JsonDoclet.java:141)
    [ERROR]         at jdk.javadoc/jdk.javadoc.internal.tool.Start.parseAndExecute(Start.java:575)
    [ERROR]         at jdk.javadoc/jdk.javadoc.internal.tool.Start.begin(Start.java:398)
    [ERROR]         at jdk.javadoc/jdk.javadoc.internal.tool.Start.begin(Start.java:347)
    [ERROR]         at jdk.javadoc/jdk.javadoc.internal.tool.Main.execute(Main.java:57)
    [ERROR]         at jdk.javadoc/jdk.javadoc.internal.tool.Main.main(Main.java:46)
    [ERROR] 2 errors