### PR TITLE
Remove dependency on jcifs (GEA-14911)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Dependency on org.samba.jcifs.
+
 ### Added
 
 - `itemState` to `vault.requests.UpdateRequest`.

--- a/packages/pangea-sdk/pom.xml
+++ b/packages/pangea-sdk/pom.xml
@@ -65,11 +65,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.samba.jcifs</groupId>
-      <artifactId>jcifs</artifactId>
-      <version>1.3.3</version>
-    </dependency>
-    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
       <version>1.78.1</version>

--- a/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/Utils.java
+++ b/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/Utils.java
@@ -7,11 +7,13 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.zip.CRC32C;
-import jcifs.util.Hexdump;
-import jcifs.util.MD4;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.bouncycastle.crypto.digests.MD4Digest;
+import org.bouncycastle.util.encoders.Hex;
 
 public final class Utils {
 
@@ -36,14 +38,12 @@ public final class Utils {
 	}
 
 	public static String hashNTLM(String data) {
-		try {
-			byte[] unicodePasswordBytes = data.getBytes("UTF-16LE");
-			MD4 md4 = new jcifs.util.MD4();
-			byte[] ntlmHash = md4.digest(unicodePasswordBytes);
-			return Hexdump.toHexString(ntlmHash, 0, ntlmHash.length * 2);
-		} catch (Exception e) {
-			return "";
-		}
+		byte[] unicodePasswordBytes = data.getBytes(StandardCharsets.UTF_16LE);
+		final var md4 = new MD4Digest();
+		md4.update(unicodePasswordBytes, 0, unicodePasswordBytes.length);
+		final var ntlmHash = new byte[md4.getDigestSize()];
+        md4.doFinal(ntlmHash, 0);
+		return Hex.toHexString(ntlmHash).toUpperCase(Locale.ROOT);
 	}
 
 	public static String hashSHA256fromFilepath(String filepath) throws IOException, FileNotFoundException {
@@ -70,7 +70,7 @@ public final class Utils {
 				size += bytesRead;
 				crc32c.update(buffer, 0, bytesRead);
 			}
-			crc = Hexdump.toHexString(crc32c.getValue(), 8).toLowerCase();
+			crc = Long.toHexString(crc32c.getValue()).toLowerCase(Locale.ROOT);
 		} catch (IOException e) {
 			throw new PangeaException(String.format("Failed to read file: %s", file.getAbsolutePath()), e);
 		}

--- a/packages/pangea-sdk/src/test/java/cloud/pangeacyber/pangea/UtilsTest.java
+++ b/packages/pangea-sdk/src/test/java/cloud/pangeacyber/pangea/UtilsTest.java
@@ -2,18 +2,20 @@ package cloud.pangeacyber.pangea;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.UnsupportedEncodingException;
-import org.junit.Before;
+import cloud.pangeacyber.pangea.exceptions.PangeaException;
 import org.junit.Test;
 
 public class UtilsTest {
 
-	@Before
-	public void setUp() {}
+	@Test
+	public void testHashNTLM() {
+		assertEquals("31D6CFE0D16AE931B73C59D7E0C089C0", Utils.hashNTLM(""));
+		assertEquals("8846F7EAEE8FB117AD06BDD830B7586C", Utils.hashNTLM("password"));
+	}
 
 	@Test
-	public void testHashNTLM() throws UnsupportedEncodingException {
-		String hash = Utils.hashNTLM("password");
-		assertEquals(hash, "8846F7EAEE8FB117AD06BDD830B7586C");
+	public void testFileUploadParams() throws PangeaException {
+		final var params = Utils.getFileUploadParams("./src/test/java/cloud/pangeacyber/pangea/testdata/testfile.pdf");
+		assertEquals("754995fb", params.getCRC32C());
 	}
 }


### PR DESCRIPTION
Bringing in a whole CIFS/SMB implementation just for MD4 and hex data conversion is excessive. This patch replaces the functions we were using from jcifs with Bouncy Castle equivalents, which we were already using elsewhere anyways.