### PR TITLE
Run CI on Java 21 (GEA-14912)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 default:
-  image: maven:3-openjdk-18@sha256:f22971fa3103b6a5145741dd80cc1660490bef93deb6400276c96dadf5bfd75f
+  image: maven:3.9.7-eclipse-temurin-21
   tags:
     - pangea-internal
 

--- a/examples/.examples-ci.yml
+++ b/examples/.examples-ci.yml
@@ -56,7 +56,7 @@ examples:
           - vault/sign
           - audit/log_bulk_async_with_vault
           - vault/get
-  image: maven:3.9.6-eclipse-temurin-${JAVA_VERSION}
+  image: maven:3.9.7-eclipse-temurin-${JAVA_VERSION}
   before_script:
     - export PANGEA_AUDIT_CONFIG_ID="$(eval echo \$PANGEA_AUDIT_CONFIG_ID_1_LVE_AWS)"
     - export PANGEA_AUDIT_CUSTOM_SCHEMA_TOKEN="$(eval echo \$PANGEA_INTEGRATION_CUSTOM_SCHEMA_TOKEN_LVE_AWS)"


### PR DESCRIPTION
Support for the OpenJDK 18 build from Oracle ended on September 2022, so stop using that build in CI and use Java 21 instead.