### PR TITLE
Retry on server errors (PAN-13550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Improvements in verification of Audit consistency proofs
+- Improvements in verification of Audit consistency proofs.
+
+### Changed
+
+- HTTP/503 and HTTP/504 responses are now retried, with a configurable interval
+  and retry count.
 
 ## [3.9.0] - 2024-06-07
 

--- a/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/Config.java
+++ b/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/Config.java
@@ -37,6 +37,12 @@ public final class Config {
 	// Timeout used to poll results after 202 (in secs)
 	long pollResultTimeout;
 
+	/** Maximum number of allowed retries on server errors. */
+	final int maxRetries;
+
+	/** Retry interval between subsequent requests. */
+	final Duration retryInterval;
+
 	protected Config(Builder builder) {
 		this.domain = builder.domain;
 		this.token = builder.token;
@@ -47,6 +53,8 @@ public final class Config {
 		this.queuedRetryEnabled = builder.queuedRetryEnabled;
 		this.pollResultTimeout = builder.pollResultTimeout;
 		this.configID = builder.configID;
+		this.maxRetries = builder.maxRetries;
+		this.retryInterval = builder.retryInterval;
 	}
 
 	public String getToken() {
@@ -83,6 +91,16 @@ public final class Config {
 
 	public String getConfigID() {
 		return configID;
+	}
+
+	/** @return Maximum number of allowed retries on server errors. */
+	public final int getMaxRetries() {
+		return this.maxRetries;
+	}
+
+	/** @return Retry interval between subsequent requests. */
+	public final Duration getRetryInterval() {
+		return this.retryInterval;
 	}
 
 	URI getServiceUrl(String serviceName, String path) {
@@ -207,6 +225,8 @@ public final class Config {
 		boolean queuedRetryEnabled;
 		long pollResultTimeout;
 		String configID;
+		int maxRetries;
+		Duration retryInterval;
 
 		public Builder(String token, String domain) {
 			this.token = token;
@@ -217,6 +237,8 @@ public final class Config {
 			this.customUserAgent = "";
 			this.queuedRetryEnabled = true;
 			this.pollResultTimeout = 240;
+			this.maxRetries = 3;
+			this.retryInterval = Duration.ofSeconds(5);
 		}
 
 		public Builder queuedRetryEnabled(boolean queuedRetryEnabled) {
@@ -255,6 +277,18 @@ public final class Config {
 		@Deprecated
 		public Builder configID(String configID) {
 			this.configID = configID;
+			return this;
+		}
+
+		/** Set the maximum number of allowed retries on server errors. */
+		public Builder maxRetries(int maxRetries) {
+			this.maxRetries = maxRetries;
+			return this;
+		}
+
+		/** Set the retry interval between subsequent requests. */
+		public Builder retryInterval(Duration retryInterval) {
+			this.retryInterval = retryInterval;
 			return this;
 		}
 

--- a/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/Response.java
+++ b/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/Response.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.HttpResponse;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Response<Result> extends ResponseHeader {
@@ -14,7 +14,7 @@ public class Response<Result> extends ResponseHeader {
 	Result result;
 
 	@JsonIgnore
-	CloseableHttpResponse httpResponse;
+	HttpResponse httpResponse;
 
 	@JsonIgnore
 	AcceptedResult acceptedResult;
@@ -31,7 +31,7 @@ public class Response<Result> extends ResponseHeader {
 		return result;
 	}
 
-	public CloseableHttpResponse getHttpResponse() {
+	public HttpResponse getHttpResponse() {
 		return httpResponse;
 	}
 

--- a/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/ServerErrorRetryStrategy.java
+++ b/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/ServerErrorRetryStrategy.java
@@ -1,0 +1,54 @@
+package cloud.pangeacyber.pangea;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.ServiceUnavailableRetryStrategy;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.Args;
+
+/**
+ * {@link ServiceUnavailableRetryStrategy} implementation that retries HTTP/503
+ * and HTTP/504 responses.
+ */
+public final class ServerErrorRetryStrategy implements ServiceUnavailableRetryStrategy {
+
+	/** Maximum number of allowed retries. */
+	private final int maxRetries;
+
+	/** Retry interval between subsequent requests, in milliseconds. */
+	private final long retryInterval;
+
+	public ServerErrorRetryStrategy() {
+		this(3, 5000);
+	}
+
+	public ServerErrorRetryStrategy(final int maxRetries, final long retryInterval) {
+		super();
+		Args.positive(maxRetries, "maxRetries");
+		Args.positive(retryInterval, "retryInterval");
+		this.maxRetries = maxRetries;
+		this.retryInterval = retryInterval;
+	}
+
+	/**
+	 * Determines if a method should be retried given the response from the server.
+	 * @param response Response from the server.
+	 * @param executionCount Number of times this method has been unsuccessfully executed.
+	 * @param context Context for the request execution.
+	 * @return true if the method should be retried, false otherwise.
+	 */
+	@Override
+	public final boolean retryRequest(HttpResponse response, int executionCount, HttpContext context) {
+		final var statusCode = response.getStatusLine().getStatusCode();
+		return (
+			executionCount <= maxRetries &&
+			(statusCode == HttpStatus.SC_SERVICE_UNAVAILABLE || statusCode == HttpStatus.SC_GATEWAY_TIMEOUT)
+		);
+	}
+
+	/** @return The interval between the subsequent auto-retries. */
+	@Override
+	public final long getRetryInterval() {
+		return this.retryInterval;
+	}
+}

--- a/packages/pangea-sdk/src/test/java/cloud/pangeacyber/pangea/ClientTest.java
+++ b/packages/pangea-sdk/src/test/java/cloud/pangeacyber/pangea/ClientTest.java
@@ -1,20 +1,86 @@
 package cloud.pangeacyber.pangea;
 
+import cloud.pangeacyber.pangea.exceptions.PangeaAPIException;
+import cloud.pangeacyber.pangea.exceptions.PangeaException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.bootstrap.HttpServer;
+import org.apache.http.impl.bootstrap.ServerBootstrap;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpRequestHandler;
+import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 
-class TestClient extends BaseClient {
+final class TestClient extends BaseClient {
 
-	public TestClient() {
-		super(new BaseClient.Builder<>(new Config.Builder("token", "domain.com").build()), "test");
+	public TestClient(String domain) {
+		super(
+			new BaseClient.Builder<>(new Config.Builder("token", domain).enviroment("local").insecure(true).build()),
+			"test"
+		);
+	}
+
+	public Response<Void> ping() throws PangeaException, PangeaAPIException {
+		return post("/v1/ping", new BaseRequest(), new TypeReference<Response<Void>>() {});
 	}
 }
 
 public class ClientTest {
 
-	BaseClient client;
+	private class MockServerErrorHandler implements HttpRequestHandler {
+
+		private int attempts = 0;
+
+		@Override
+		public void handle(final HttpRequest request, final HttpResponse response, final HttpContext context)
+			throws HttpException, IOException {
+			// Fail twice, then succeed from then on.
+			final var success = attempts++ < 2;
+
+			response.setStatusCode(success ? HttpStatus.SC_OK : HttpStatus.SC_BAD_GATEWAY);
+
+			// Response body.
+			final var responseBody = new ResponseHeader();
+			responseBody.setStatus(success ? ResponseStatus.SUCCESS.toString() : ResponseStatus.FAILED.toString());
+			response.setEntity(new StringEntity(objectMapper.writeValueAsString(responseBody)));
+		}
+	}
+
+	private static final ObjectMapper objectMapper = JsonMapper.builder().findAndAddModules().build();
+
+	private static ServerBootstrap serverBootstrap;
+	private static HttpServer server;
+	private static TestClient client;
 
 	@Before
-	public void setUp() {
-		client = new TestClient();
+	public void setUp() throws IOException {
+		serverBootstrap = ServerBootstrap.bootstrap().setServerInfo("TEST/1.1");
+		serverBootstrap.registerHandler("*", new MockServerErrorHandler());
+		server = serverBootstrap.create();
+		server.start();
+
+		client = new TestClient("localhost:" + server.getLocalPort());
+	}
+
+	@After
+	public void shutDown() {
+		if (server != null) {
+			server.shutdown(10, TimeUnit.SECONDS);
+		}
+	}
+
+	@Test
+	public void retryServerErrors() throws PangeaException, PangeaAPIException {
+		// Should not throw thanks to retries.
+		client.ping();
 	}
 }


### PR DESCRIPTION
Seems like this was missed in a565327. HTTP/503 and HTTP/504 responses are now retried a configurable amount of times, with an equally configurable delay between retries. The defaults are 3 retries on a 5 second interval, which mirrors the Python SDK.