### PR TITLE
Add `"state"` to `authn.models.Authenticator` (PAN-15469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - AuthN user password expiration support.
+- `"state"` and other new properties to `authn.models.Authenticator`.
+
+### Changed
+
+- `isEnable()` in `authn.models.Authenticator` has been renamed to
+  `isEnabled()`. The previous name did not match the name used in the API's
+  response schema and JSON deserialization was not set up correctly, so
+  `isEnable()` was unusable anyways.
 
 ## [3.10.1] - 2024-06-24
 

--- a/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/authn/models/Authenticator.java
+++ b/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/authn/models/Authenticator.java
@@ -7,50 +7,110 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Authenticator {
 
+	/** An ID for an authenticator. */
 	@JsonProperty("id")
 	private String id;
 
+	/** An authentication mechanism. */
 	@JsonProperty("type")
 	private String type;
 
-	@JsonProperty("enable")
-	private boolean enable;
-
+	/** Provider. */
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	@JsonProperty("provider")
 	private String provider;
 
+	/** Provider name. */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonProperty("provider_name")
+	private String providerName;
+
+	/** RPID. */
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	@JsonProperty("rpid")
 	private String rpid;
 
+	/** Enabled. */
+	@JsonProperty("enabled")
+	private boolean enabled;
+
+	/** Phase. */
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	@JsonProperty("phase")
 	private String phase;
 
+	/** Enrolling browser. */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonProperty("enrolling_browser")
+	private String enrollingBrowser;
+
+	/** Enrolling IP. */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonProperty("enrolling_ip")
+	private String enrollingIp;
+
+	/** A time in ISO-8601 format. */
+	@JsonProperty("created_at")
+	private String createdAt;
+
+	/** A time in ISO-8601 format. */
+	@JsonProperty("updated_at")
+	private String updatedAt;
+
 	public Authenticator() {}
 
+	/** An ID for an authenticator. */
 	public String getId() {
 		return id;
 	}
 
+	/** An authentication mechanism. */
 	public String getType() {
 		return type;
 	}
 
-	public boolean isEnable() {
-		return enable;
-	}
-
+	/** Provider. */
 	public String getProvider() {
 		return provider;
 	}
 
+	/** Provider name. */
+	public String getProviderName() {
+		return providerName;
+	}
+
+	/** RPID. */
 	public String getRpid() {
 		return rpid;
 	}
 
+	/** Enabled. */
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	/** Phase. */
 	public String getPhase() {
 		return phase;
+	}
+
+	/** Enrolling browser. */
+	public String getEnrollingBrowser() {
+		return enrollingBrowser;
+	}
+
+	/** Enrolling IP. */
+	public String getEnrollingIp() {
+		return enrollingIp;
+	}
+
+	/** A time in ISO-8601 format. */
+	public String getCreatedAt() {
+		return createdAt;
+	}
+
+	/** A time in ISO-8601 format. */
+	public String getUpdatedAt() {
+		return updatedAt;
 	}
 }

--- a/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/authn/models/User.java
+++ b/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/authn/models/User.java
@@ -126,6 +126,7 @@ public class User {
 		return lastLoginCountry;
 	}
 
+	/** A list of authenticators. */
 	public Authenticator[] getAuthenticators() {
 		return authenticators;
 	}

--- a/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/authn/results/UserAuthenticatorsListResult.java
+++ b/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/authn/results/UserAuthenticatorsListResult.java
@@ -7,9 +7,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class UserAuthenticatorsListResult {
 
+	/** A list of authenticators. */
 	@JsonProperty("authenticators")
 	Authenticator[] authenticators;
 
+	/** A list of authenticators. */
 	public Authenticator[] getAuthenticators() {
 		return authenticators;
 	}


### PR DESCRIPTION
Also added other missing properties. Many of these do not have descriptions in the API documentation so the docs here are skim.

`isEnable()` has been renamed to `isEnabled()` to match the API's response schema. This is a breaking change but the current property isn't being deserialized properly anyways so it's been unusable this whole time.