### PR TITLE
Correct content type and encoding for request bodies (PAN-16385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- POST request bodies now have a content type of "application/json" with UTF8
+  encoding.
+
 ## 3.13.0 - 2024-08-20
 
 ### Added

--- a/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/BaseClient.java
+++ b/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/BaseClient.java
@@ -306,7 +306,7 @@ public abstract class BaseClient {
 
 	protected HttpPost buildPostRequest(URI url, String body) throws UnsupportedEncodingException {
 		HttpPost httpPost = new HttpPost(url);
-		httpPost.setEntity(new StringEntity(body));
+		httpPost.setEntity(new StringEntity(body, ContentType.APPLICATION_JSON));
 		fillHeaders(httpPost);
 		return httpPost;
 	}
@@ -315,7 +315,7 @@ public abstract class BaseClient {
 		HttpPost httpPost = new HttpPost(url);
 
 		final MultipartEntityBuilder builder = MultipartEntityBuilder.create();
-		final StringBody requestBody = new StringBody(body, ContentType.create("application/json"));
+		final StringBody requestBody = new StringBody(body, ContentType.APPLICATION_JSON);
 		builder.addPart("request", requestBody);
 		builder.addBinaryBody(fileData.getName(), fileData.getFile(), ContentType.APPLICATION_OCTET_STREAM, "file.exe");
 
@@ -345,7 +345,7 @@ public abstract class BaseClient {
 				if (entry.getValue() instanceof String) {
 					final StringBody requestBody = new StringBody(
 						(String) entry.getValue(),
-						ContentType.create("application/json")
+						ContentType.APPLICATION_JSON
 					);
 					String key = entry.getKey();
 					builder.addPart(key, requestBody);

--- a/packages/pangea-sdk/src/test/java/cloud/pangeacyber/pangea/audit/ITAuditTest.java
+++ b/packages/pangea-sdk/src/test/java/cloud/pangeacyber/pangea/audit/ITAuditTest.java
@@ -20,6 +20,7 @@ import cloud.pangeacyber.pangea.audit.results.LogBulkResult;
 import cloud.pangeacyber.pangea.audit.results.RootResult;
 import cloud.pangeacyber.pangea.exceptions.*;
 import com.fasterxml.jackson.core.type.TypeReference;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -1236,5 +1237,15 @@ public class ITAuditTest {
 		System.out.printf("Finished everything in %d ms.\n", totalEstimatedTime / (1000 * 1000));
 		System.out.printf("Tasks: %d. Threads: %d.\n", taskCount, threadsCount);
 		service.shutdown();
+	}
+
+	@Test
+	public void testEncoding() throws PangeaAPIException, PangeaException {
+		final var event = new StandardEvent.Builder(
+			new String(new byte[] { 0x00, (byte) 0xE2, (byte) 0x98 }, StandardCharsets.UTF_16)
+		)
+			.build();
+		final var response = clientGeneral.log(event, null);
+		assertTrue(response.isOk());
 	}
 }


### PR DESCRIPTION
Previously, POST request bodies were defaulting to text/plain, which has a default encoding of ISO-8859-1. The platform expects application/json and UTF8.