### PR TITLE
Add option to validate Audit events before sending them (PAN-16602)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Secure Audit Log events may now be validated against the service's OpenAPI
+  spec before sending them. This feature is disabled by default and can be
+  enabled by calling `withSchemaValidation(true)` when building an
+  `AuditClient`.
+
 ## 3.13.1 - 2024-08-23
 
 ### Fixed

--- a/packages/pangea-sdk/pom.xml
+++ b/packages/pangea-sdk/pom.xml
@@ -114,6 +114,16 @@
       <artifactId>httpclient</artifactId>
       <version>4.5.14</version>
     </dependency>
+    <dependency>
+      <groupId>io.swagger.parser.v3</groupId>
+      <artifactId>swagger-parser</artifactId>
+      <version>2.1.22</version>
+    </dependency>
+    <dependency>
+      <groupId>com.networknt</groupId>
+      <artifactId>json-schema-validator</artifactId>
+      <version>1.5.1</version>
+    </dependency>
 
     <!-- Testing -->
     <dependency>

--- a/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/BaseClient.java
+++ b/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/BaseClient.java
@@ -33,7 +33,6 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.FileEntity;
 import org.apache.http.entity.StringEntity;
@@ -162,7 +161,7 @@ final class InternalHttpResponse {
 
 public abstract class BaseClient {
 
-	private static final ObjectMapper objectMapper = JsonMapper
+	protected static final ObjectMapper objectMapper = JsonMapper
 		.builder()
 		.findAndAddModules()
 		.defaultTimeZone(TimeZone.getTimeZone(ZoneOffset.UTC))
@@ -450,6 +449,21 @@ public abstract class BaseClient {
 	}
 
 	/**
+	 * Perform a HTTP POST request and return the request body as a string.
+	 *
+	 * @param <Req> Request body type.
+	 * @param path Request URL path.
+	 * @param request Request body.
+	 * @return Response body as a string.
+	 * @throws PangeaException Thrown if an error occurs during the operation.
+	 * @throws PangeaAPIException Thrown if the API returns an error response.
+	 */
+	protected <Req extends BaseRequest> String post(String path, Req request)
+		throws PangeaException, PangeaAPIException {
+		return this.postSingle(this.config.getServiceUrl(this.serviceName, path), request, null).getBody();
+	}
+
+	/**
 	 * Perform a HTTP GET request.
 	 *
 	 * @param <ResponseType> Response body type.
@@ -612,7 +626,7 @@ public abstract class BaseClient {
 			response = postSingle(url, request, fileData);
 		}
 
-		if (postConfig.getPollResult() == true) {
+		if (postConfig.getPollResult()) {
 			response = this.handleQueued(response);
 		}
 		return checkResponse(response, responseTypeRef, url.toString());

--- a/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/Config.java
+++ b/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/Config.java
@@ -128,7 +128,7 @@ public final class Config {
 			b.append(domain);
 		} else {
 			b.append(insecure ? "http://" : "https://");
-			if (enviroment != "local") {
+			if (!enviroment.equals("local")) {
 				b.append(serviceName);
 				b.append('.');
 			}

--- a/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/audit/SearchEvent.java
+++ b/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/audit/SearchEvent.java
@@ -74,7 +74,7 @@ public class SearchEvent {
 	}
 
 	public boolean isPublished() {
-		return published == true;
+		return published;
 	}
 
 	public EventVerification getMembershipVerification() {

--- a/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/exceptions/PangeaException.java
+++ b/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/exceptions/PangeaException.java
@@ -1,21 +1,14 @@
 package cloud.pangeacyber.pangea.exceptions;
 
-import java.lang.Exception;
-
 public class PangeaException extends Exception {
 
-	Throwable cause;
-
 	public PangeaException(String message, Throwable cause) {
-		super(message);
-		this.cause = cause;
+		super(message, cause);
 	}
 
-	public Throwable getCause() {
-		return cause;
-	}
-
+	/** @deprecated */
+	@Deprecated
 	public Throwable getCasue() {
-		return cause;
+		return getCause();
 	}
 }

--- a/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/exceptions/SchemaValidationException.java
+++ b/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/exceptions/SchemaValidationException.java
@@ -1,0 +1,40 @@
+package cloud.pangeacyber.pangea.exceptions;
+
+import com.networknt.schema.ValidationMessage;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+/**
+ * Thrown when a Secure Audit Log event does not validate against the expected
+ * event schema.
+ */
+public class SchemaValidationException extends RuntimeException {
+
+	private final transient Collection<ValidationMessage> validationMessages;
+
+	public SchemaValidationException(Collection<ValidationMessage> validationMessages) {
+		this.validationMessages = validationMessages;
+	}
+
+	public SchemaValidationException(String message) {
+		super(message);
+		this.validationMessages = null;
+	}
+
+	public SchemaValidationException(Throwable throwable) {
+		super(throwable);
+		this.validationMessages = null;
+	}
+
+	public SchemaValidationException(String message, Throwable throwable) {
+		super(message, throwable);
+		this.validationMessages = null;
+	}
+
+	@Override
+	public String getMessage() {
+		return this.validationMessages != null
+			? this.validationMessages.stream().map(ValidationMessage::getMessage).collect(Collectors.joining("\n"))
+			: super.getMessage();
+	}
+}

--- a/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/exceptions/SchemaValidationException.java
+++ b/packages/pangea-sdk/src/main/java/cloud/pangeacyber/pangea/exceptions/SchemaValidationException.java
@@ -21,6 +21,11 @@ public class SchemaValidationException extends RuntimeException {
 		this.validationMessages = null;
 	}
 
+	public SchemaValidationException(String message, Collection<ValidationMessage> validationMessages) {
+		super(message);
+		this.validationMessages = validationMessages;
+	}
+
 	public SchemaValidationException(Throwable throwable) {
 		super(throwable);
 		this.validationMessages = null;
@@ -34,7 +39,11 @@ public class SchemaValidationException extends RuntimeException {
 	@Override
 	public String getMessage() {
 		return this.validationMessages != null
-			? this.validationMessages.stream().map(ValidationMessage::getMessage).collect(Collectors.joining("\n"))
+			? super.getMessage() +
+			System.lineSeparator() +
+			this.validationMessages.stream()
+				.map(ValidationMessage::getMessage)
+				.collect(Collectors.joining(System.lineSeparator()))
 			: super.getMessage();
 	}
 }

--- a/packages/pangea-sdk/src/test/java/cloud/pangeacyber/pangea/audit/ITAuditTest.java
+++ b/packages/pangea-sdk/src/test/java/cloud/pangeacyber/pangea/audit/ITAuditTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 public class ITAuditTest {
 
 	Config cfgGeneral;
+	Config customSchemaCfg;
 	AuditClient clientGeneral, clientGeneralNoQueue, localSignClient, localSignInfoClient, vaultSignClient, signNtenandIDClient, customSchemaClient, localSignCustomSchemaClient;
 	static TestEnvironment environment;
 	CustomEvent customEvent;
@@ -61,7 +62,7 @@ public class ITAuditTest {
 		this.cfgGeneral = Config.fromIntegrationEnvironment(environment);
 		Config cfgGeneralNoQueue = Config.fromIntegrationEnvironment(environment);
 		cfgGeneralNoQueue.setQueuedRetryEnabled(false);
-		Config customSchemaCfg = Config.fromCustomSchemaIntegrationEnvironment(environment);
+		this.customSchemaCfg = Config.fromCustomSchemaIntegrationEnvironment(environment);
 		Map<String, Object> pkInfo = new LinkedHashMap<String, Object>();
 		pkInfo.put("ExtraInfo", "LocalKey");
 
@@ -1247,5 +1248,35 @@ public class ITAuditTest {
 			.build();
 		final var response = clientGeneral.log(event, null);
 		assertTrue(response.isOk());
+	}
+
+	@Test
+	void testOpenApiSchemaValidation() {
+		// Create an event with a message long enough to fail validation. It
+		// only requires a length >32766.
+		final var sb = new StringBuilder(32766 + 1);
+		for (var i = 0; i < 32766 + 1; i++) {
+			sb.append('a');
+		}
+		final var invalidEvent = new StandardEvent(sb.toString());
+		final IEvent[] invalidEvents = { invalidEvent };
+
+		// Create a client with schema validation enabled.
+		final var client = new AuditClient.Builder(cfgGeneral).withSchemaValidation(true).build();
+
+		assertThrows(SchemaValidationException.class, () -> client.log(invalidEvent, null));
+		assertThrows(SchemaValidationException.class, () -> client.logBulk(invalidEvents, null));
+		assertThrows(SchemaValidationException.class, () -> client.logBulkAsync(invalidEvents, null));
+
+		// Also works with custom schemas.
+		final var invalidCustomEvent = new CustomEvent.Builder(sb.toString()).build();
+		final IEvent[] invalidCustomEvents = { invalidCustomEvent };
+		final var customClient = new AuditClient.Builder(this.customSchemaCfg)
+			.withCustomSchema(CustomEvent.class)
+			.withSchemaValidation(true)
+			.build();
+		assertThrows(SchemaValidationException.class, () -> customClient.log(invalidCustomEvent, null));
+		assertThrows(SchemaValidationException.class, () -> customClient.logBulk(invalidCustomEvents, null));
+		assertThrows(SchemaValidationException.class, () -> customClient.logBulkAsync(invalidCustomEvents, null));
 	}
 }

--- a/packages/pangea-sdk/src/test/java/cloud/pangeacyber/pangea/audit/ITAuditTest.java
+++ b/packages/pangea-sdk/src/test/java/cloud/pangeacyber/pangea/audit/ITAuditTest.java
@@ -1,5 +1,6 @@
 package cloud.pangeacyber.pangea.audit;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -1267,9 +1268,12 @@ public class ITAuditTest {
 		assertThrows(SchemaValidationException.class, () -> client.log(invalidEvent, null));
 		assertThrows(SchemaValidationException.class, () -> client.logBulk(invalidEvents, null));
 		assertThrows(SchemaValidationException.class, () -> client.logBulkAsync(invalidEvents, null));
+		assertDoesNotThrow(() -> client.log(new StandardEvent(MSG_NO_SIGNED), null));
 
 		// Also works with custom schemas.
-		final var invalidCustomEvent = new CustomEvent.Builder(sb.toString()).build();
+		final var invalidCustomEvent = new CustomEvent.Builder(sb.toString())
+			.fieldTime("definitely not a date-time")
+			.build();
 		final IEvent[] invalidCustomEvents = { invalidCustomEvent };
 		final var customClient = new AuditClient.Builder(this.customSchemaCfg)
 			.withCustomSchema(CustomEvent.class)
@@ -1278,5 +1282,6 @@ public class ITAuditTest {
 		assertThrows(SchemaValidationException.class, () -> customClient.log(invalidCustomEvent, null));
 		assertThrows(SchemaValidationException.class, () -> customClient.logBulk(invalidCustomEvents, null));
 		assertThrows(SchemaValidationException.class, () -> customClient.logBulkAsync(invalidCustomEvents, null));
+		assertDoesNotThrow(() -> customClient.log(customEvent, null));
 	}
 }


### PR DESCRIPTION
When building an `AuditClient`, users can now enable schema validation of all events sent through the client via `withSchemaValidation(true)`. When enabled, the client will fetch (and cache) the event schema from the OpenAPI spec and validate all events against it before sending them. When bulk logging events, the validation ends at the first event that fails validation.